### PR TITLE
Add instance tags+filters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+TEST?=$(shell go list ./... | grep -v vendor)
+VET?=$(shell ls -d */ | grep -v vendor | grep -v website)
+UNFORMATTED_FILES=$(shell find . -not -path "./vendor/*" -name "*.go" | xargs gofmt -s -l)
+
+.PHONY: build
+build:
+	go build -v
+
+.PHONY: install
+install:
+	go install -v
+
+.PHONY: fmt
+fmt:
+	@gofmt -w -s main.go $(UNFORMATTED_FILES)
+
+.PHONY: fmt-check
+fmt-check:
+	@echo "==> Checking that code complies with gofmt requirements..."
+	@if [ ! -z "$(UNFORMATTED_FILES)" ]; then \
+		echo "gofmt needs to be run on the following files:"; \
+		echo "$(UNFORMATTED_FILES)" | xargs -n1; \
+		echo "You can use the command: \`make fmt\` to reformat code."; \
+		exit 1; \
+	else \
+		echo "Check passed."; \
+	fi
+
+.PHONY: test
+test: fmt-check
+	@go test $(TEST) $(TESTARGS) -timeout=2m
+	@go tool vet $(VET)  ; if [ $$? -eq 1 ]; then \
+		echo "ERROR: Vet found problems in the code."; \
+		exit 1; \
+	fi

--- a/builder/tencloud/builder.go
+++ b/builder/tencloud/builder.go
@@ -72,7 +72,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			ForceDeregister: b.config.ForceDeregister,
 		},
 		&StepSourceImageInfo{
-			SourceImage: b.config.SourceImageId,
+			SourceImage:       b.config.SourceImageId,
+			SourceImageFilter: b.config.SourceImageFilter,
 		},
 		&StepKeyPair{
 			Debug:                b.config.PackerDebug,
@@ -84,6 +85,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&StepRunInstance{
 			AvailabilityZone:        b.config.AvailabilityZone,
 			SourceImageId:           b.config.SourceImageId,
+			SourceImageFilter:       b.config.SourceImageFilter,
 			InstanceType:            b.config.InstanceType,
 			InstanceChargeType:      b.config.InstanceChargeType,
 			SystemDiskType:          b.config.SystemDiskType,

--- a/builder/tencloud/builder_test.go
+++ b/builder/tencloud/builder_test.go
@@ -1,0 +1,83 @@
+package tencloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/packer/packer"
+)
+
+func testConfig() map[string]interface{} {
+	return map[string]interface{}{
+		"key_id":        "foo",
+		"key":           "bar",
+		"instance_type": "type_foo",
+		"subnet_id":     "subnet_bar",
+	}
+}
+
+func TestBuilder_ImplementsBuilder(t *testing.T) {
+	var raw interface{}
+	raw = &Builder{}
+	if _, ok := raw.(packer.Builder); !ok {
+		t.Fatalf("Builder should be a builder")
+	}
+}
+
+func TestBuilderPrepare_workingConfig(t *testing.T) {
+	var b Builder
+	config := testConfig()
+	config["source_image_id"] = "foo"
+
+	warnings, err := b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatalf("prepare should not have error: %v", err)
+	}
+}
+
+func TestBuilderPrepare_sourceImage(t *testing.T) {
+	// Both sources set, fail
+	var b Builder
+	config := testConfig()
+	config["source_image_id"] = "foo"
+	config["source_image_filters"] = map[string]interface{}{
+		"most_recent": true,
+		"filters": map[string]string{
+			"foo-filter": "foo-filter-value",
+		},
+	}
+	warnings, err := b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err == nil {
+		t.Fatal("should have errored")
+	}
+
+	// only one source set, pass
+	delete(config, "source_image_id")
+	b = Builder{}
+	warnings, err = b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %v", err)
+	}
+
+	// source_image_filter has no filters should fail
+	delete(config, "source_image_filters")
+	config["source_image_filters"] = map[string]interface{}{
+		"most_recent": true,
+	}
+	b = Builder{}
+	warnings, err = b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err == nil {
+		t.Fatal("should have errored")
+	}
+}

--- a/builder/tencloud/state.go
+++ b/builder/tencloud/state.go
@@ -42,13 +42,13 @@ func ImageExistsRefreshFunc(tc *tcapi.Client, imageName string) StateRefreshFunc
 	return func() (interface{}, string, error) {
 		req := &tcapi.DescribeImagesRequest{
 			Filters: []tcapi.Filter{
-				tcapi.Filter{
+				{
 					Name: "image-type",
 					Values: []string{
 						"PRIVATE_IMAGE",
 					},
 				},
-				tcapi.Filter{
+				{
 					Name: "image-name",
 					Values: []string{
 						imageName,

--- a/builder/tencloud/step_deregister_image.go
+++ b/builder/tencloud/step_deregister_image.go
@@ -30,13 +30,13 @@ func (step *StepDeregisterImage) Run(ctx context.Context, state multistep.StateB
 		thisClient := tc.Copy(region, nil)
 		req := &tcapi.DescribeImagesRequest{
 			Filters: []tcapi.Filter{
-				tcapi.Filter{
+				{
 					Name: "image-type",
 					Values: []string{
 						"PRIVATE_IMAGE",
 					},
 				},
-				tcapi.Filter{
+				{
 					Name: "image-name",
 					Values: []string{
 						step.ImageName,

--- a/builder/tencloud/step_image_region_copy.go
+++ b/builder/tencloud/step_image_region_copy.go
@@ -66,13 +66,13 @@ func (step *StepImageRegionCopy) Run(ctx context.Context, state multistep.StateB
 
 		req := &tcapi.DescribeImagesRequest{
 			Filters: []tcapi.Filter{
-				tcapi.Filter{
+				{
 					Name: "image-type",
 					Values: []string{
 						"PRIVATE_IMAGE",
 					},
 				},
-				tcapi.Filter{
+				{
 					Name: "image-name",
 					Values: []string{
 						step.Name,

--- a/builder/tencloud/step_source_image_info.go
+++ b/builder/tencloud/step_source_image_info.go
@@ -5,32 +5,46 @@ import (
 	"fmt"
 
 	"github.com/3van/tencloud-go"
-
 	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/hashicorp/packer/packer"
 )
 
 type StepSourceImageInfo struct {
-	SourceImage string
+	SourceImage       string
+	SourceImageFilter TagFilterOptions
 }
 
 func (step *StepSourceImageInfo) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packer.Ui)
 	tc := state.Get("tc").(*tcapi.Client)
 
-	req := &tcapi.DescribeImagesRequest{
-		ImageIds: []string{
-			step.SourceImage,
-		},
+	if step.SourceImageFilter.Empty() {
+		req := &tcapi.DescribeImagesRequest{
+			ImageIds: []string{
+				step.SourceImage,
+			},
+		}
+		resp, err := tc.DescribeImages(req)
+		if err != nil {
+			state.Put("error", fmt.Errorf("error querying source image: %s", err))
+			return multistep.ActionHalt
+		}
+		if len(resp.ImageSet) < 1 {
+			state.Put("error", fmt.Errorf("no AMI '%s' was found", step.SourceImage))
+			return multistep.ActionHalt
+		}
+		state.Put("source_image", resp.ImageSet[0])
+		return multistep.ActionContinue
 	}
-	resp, err := tc.DescribeImages(req)
+
+	ui.Say("discovering source image from filters")
+	image, err := step.SourceImageFilter.FindImage(tc)
 	if err != nil {
-		state.Put("error", fmt.Errorf("error querying source image: %s", err))
+		state.Put("error", fmt.Errorf("Could not find source image given filters: %v", err))
 		return multistep.ActionHalt
 	}
-	if len(resp.ImageSet) < 1 {
-		state.Put("error", fmt.Errorf("no AMI '%s' was found", step.SourceImage))
-		return multistep.ActionHalt
-	}
-	state.Put("source_image", resp.ImageSet[0])
+	ui.Say("using discovered image id: " + image.ImageId)
+	state.Put("source_image", *image)
 	return multistep.ActionContinue
 }
 

--- a/builder/tencloud/tags.go
+++ b/builder/tencloud/tags.go
@@ -1,0 +1,173 @@
+package tencloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/3van/tencloud-go"
+)
+
+// TagMap is a helper type for a string=>string map
+type TagMap map[string]string
+
+// TagFilterOptions holds all of the potential filters for describing a tc image
+type TagFilterOptions struct {
+	Filters        map[string]string `mapstructure:"filters"`
+	TagFilters     map[string]string `mapstructure:"tag_filters"`
+	TagFilterDelim string            `mapstructure:"tag_filter_delimiter"`
+	MostRecent     bool              `mapstructure:"most_recent"`
+}
+
+// IsSet determines if the TagMap is set or not
+func (t TagMap) IsSet() bool {
+	return len(t) > 0
+}
+
+// Flatten well... flattens the tag map with the supplied delimiter
+func (t TagMap) Flatten(delim string) string {
+	var res string
+	for k, v := range t {
+		res = fmt.Sprintf("%s:%s=%s", res, k, v)
+	}
+
+	return res
+}
+
+// Empty determines if the TagFilterOptions is set or not
+func (t TagFilterOptions) Empty() bool {
+	return len(t.Filters) == 0 && len(t.TagFilters) == 0
+}
+
+// IsDelimSet checks if there is a delimeter set for tag filters or not
+func (t TagFilterOptions) IsDelimSet() bool {
+	return t.TagFilterDelim != ""
+}
+
+// FindImage finds a source image id given the provided filters
+func (t TagFilterOptions) FindImage(client *tcapi.Client) (*tcapi.Image, error) {
+	images := []tcapi.Image{}
+
+	req := &tcapi.DescribeImagesRequest{
+		Filters: t.tcFilters(),
+		Limit:   100,
+		Offset:  0,
+	}
+
+	for {
+		resp, err := client.DescribeImages(req)
+		if err != nil {
+			return nil, err
+		}
+		if resp.TotalCount == 0 || len(resp.ImageSet) == 0 {
+			break
+		}
+
+		// if we have no tag filters to process, add images to list
+		if len(t.TagFilters) == 0 {
+			images = append(images, resp.ImageSet...)
+		} else {
+			for i := range resp.ImageSet {
+				// Process description tags
+				if resp.ImageSet[i].ImageDescription == "" {
+					continue
+				}
+
+				// if tags match, add to list
+				if t.matchImageDesc(resp.ImageSet[i].ImageDescription) {
+					images = append(images, resp.ImageSet[i])
+				}
+			}
+		}
+
+		if resp.TotalCount > req.Limit {
+			req.Offset += req.Limit
+			continue
+		} else {
+			break
+		}
+	}
+
+	log.Printf("Found %d images", len(images))
+
+	if len(images) == 0 {
+		return nil, fmt.Errorf("no image found matching supplied filters")
+	}
+
+	if len(images) == 1 {
+		log.Printf("Using ImageID: %s", &images[0].ImageId)
+		return &images[0], nil
+	}
+
+	if !t.MostRecent {
+		return nil, fmt.Errorf("most_recent was not selected, and more than one image matching filters was found")
+	}
+
+	// Find latest image, return that ID
+	latest := images[0]
+	latestTime, err := time.Parse(time.RFC3339, images[0].CreatedTime)
+	if err != nil {
+		return nil, fmt.Errorf("getting images created time: %v", err)
+	}
+
+	for i := 1; i < len(images); i++ {
+		// parse time
+		t, err := time.Parse(time.RFC3339, images[i].CreatedTime)
+		if err != nil {
+			return nil, fmt.Errorf("getting image (%s) created time: %v", images[i].ImageName, err)
+		}
+
+		// if image is newer, sub
+		if latestTime.Before(t) {
+			latestTime = t
+			latest = images[i]
+		}
+	}
+
+	return &latest, nil
+}
+
+func (t TagFilterOptions) tcFilters() []tcapi.Filter {
+	resp := []tcapi.Filter{}
+	for k, v := range t.Filters {
+		resp = append(resp, tcapi.Filter{
+			Name:   k,
+			Values: []string{v},
+		})
+	}
+	return resp
+}
+
+func (t TagFilterOptions) matchImageDesc(iDesc string) bool {
+	// First, convert image description to map, checking length along the way.
+	iTags := map[string]string{}
+	parts := strings.Split(iDesc, t.TagFilterDelim)
+	if len(parts) == 0 {
+		return false
+	}
+	for i := range parts {
+		if parts[i] == "" {
+			continue
+		}
+		p := strings.Split(parts[i], "=")
+		if len(p) != 2 {
+			continue
+		}
+		iTags[p[0]] = p[1]
+	}
+
+	if len(iTags) == 0 {
+		return false
+	}
+
+	// now we just have to compare the two maps
+	// we check against specified tag filters. If the image has more tags, we don't care
+	for k, v := range t.TagFilters {
+		if w, ok := iTags[k]; !ok || v != w {
+			return false
+		}
+	}
+
+	return true
+}

--- a/vendor/github.com/3van/tencloud-go/tcapi.go
+++ b/vendor/github.com/3van/tencloud-go/tcapi.go
@@ -25,7 +25,7 @@ const (
 	apiPath        = "/v2/index.php"
 	apiBase        = "api.qcloud.com"
 	apiProto       = "https"
-	defaultTimeout = time.Second * 15
+	defaultTimeout = time.Second * 30
 )
 
 var moduleApiVersion = map[string]string{
@@ -119,10 +119,6 @@ func (c *Client) Do(module, request string, params interface{}) (*json.RawMessag
 		return nil, fmt.Errorf("could not parse baseURL: %s", err)
 	}
 
-	if err != nil {
-		return nil, fmt.Errorf("error encoding params struct: %s", err)
-	}
-
 	finalParams, err := query.Values(params)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse parameters: %s", err)
@@ -207,11 +203,15 @@ func (c *Client) Do(module, request string, params interface{}) (*json.RawMessag
 
 func (c *Client) signRequestParams(method string, req url.URL, params *url.Values) error {
 	method = strings.ToUpper(method)
-	req.RawQuery = params.Encode()
+	var err error
+	req.RawQuery, err = url.QueryUnescape(params.Encode())
+	if err != nil {
+		return err
+	}
 
 	message := fmt.Sprintf("%s%s%s", method, req.Hostname(), req.RequestURI())
 	sig := hmac.New(sha1.New, []byte(c.Secret))
-	_, err := sig.Write([]byte(message))
+	_, err = sig.Write([]byte(message))
 	if err != nil {
 		return err
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,10 +9,10 @@
 			"revisionTime": "2017-12-13T00:17:03Z"
 		},
 		{
-			"checksumSHA1": "vDxCcwjKogWDADdzABgYPgLdGAE=",
+			"checksumSHA1": "jFb2AnBYnEF73zUizkpZdWYgBms=",
 			"path": "github.com/3van/tencloud-go",
-			"revision": "6863fb3c3b861c492a421a4f1a63f0a1a69e6e8c",
-			"revisionTime": "2018-07-11T01:50:50Z"
+			"revision": "8c4b69b1d4216ee8120ce0534cabe492bc6082c1",
+			"revisionTime": "2018-10-05T21:35:27Z"
 		},
 		{
 			"checksumSHA1": "TgrN0l/E16deTlLYNt8wf66urSU=",


### PR DESCRIPTION
Tags are just delimited image descriptions to work around tencloud not
having native tags on an image. This allows a packer builder to use an
image filter instead of a static image id for the source image of a
build.